### PR TITLE
Make exception for filter property

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function eachVal (values) {
 module.exports = postcss.plugin('postcss-colormin', function () {
     return function (css) {
         css.eachDecl(function (decl) {
-            if (/^(?!font|-webkit-tap-highlight-color)/.test(decl.prop)) {
+            if (/^(?!font|filter|-webkit-tap-highlight-color)/.test(decl.prop)) {
                 decl.value = eachVal(decl.value);
                 decl.value = reduce(decl.value, 'gradient', function (body, fn) {
                     return fn + '(' + list.comma(body).map(eachVal).join(',') + ')';

--- a/test.js
+++ b/test.js
@@ -57,6 +57,10 @@ var tests = module.exports = [{
     message: 'should not crash on inherit in webkit tap highlight color',
     fixture: 'h1{-webkit-tap-highlight-color:inherit}',
     expected: 'h1{-webkit-tap-highlight-color:inherit}'
+}, {
+    message: 'should not minify in filter properties',
+    fixture: 'h1{filter:progid:DXImageTransform.Microsoft.gradient(startColorstr= #000000,endColorstr= #ffffff);}',
+    expected: 'h1{filter:progid:DXImageTransform.Microsoft.gradient(startColorstr= #000000,endColorstr= #ffffff);}'
 }];
 
 function process (css, options) {


### PR DESCRIPTION
This is really farfetched but it noticed that if you have a filter property contain a HEX-color (e.g. `#000000`) with a space before #, it minifies the color to `#000` which causes a invalid value in IE.